### PR TITLE
✨ feat: Mostra alerta now para usuários com role now

### DIFF
--- a/src/components/card_Update_solicitacao/index.tsx
+++ b/src/components/card_Update_solicitacao/index.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   AlertIcon,
   Box,
-  Button,
   Divider,
   Flex,
   Input,
@@ -12,7 +11,6 @@ import { UpdateSolicitacao } from "@/actions/solicitacao/service/update";
 import { CardCreateUpdate } from "@/implementes/cardCreateUpdate";
 import { ResendSms } from "@/implementes/cardCreateUpdate/butons/resendSms";
 import { SaveBtm } from "@/implementes/cardCreateUpdate/butons/saveBtm";
-
 import { AuthUser } from "@/types/session";
 import { BtCreateAlertCliente } from "../botoes/bt_create_alert_cliente";
 import CreateChamado from "../botoes/btn_chamado";
@@ -23,11 +21,6 @@ import BtnAlertNow from "../btn_alerta_now";
 import DistratoAlertPrint from "../Distrato_alert_print";
 import BotaoPausar from "../botoes/btn_pausar";
 
-import BotaoSisapp from "../botoes/bt_sisapp";
-import { cpf } from "cpf-cnpj-validator";
-import { FaNapster } from "react-icons/fa";
-
-import { SessionClient } from "@/types/session";
 
 type Props = {
   setDadosCard: solictacao.SolicitacaoObjectCompleteType;
@@ -195,7 +188,7 @@ export function CardUpdateSolicitacao({ setDadosCard, user }: Props) {
                   Hierarquia={!HierarquiaUser ? "USER" : HierarquiaUser}
                 />
               </Flex>
-              {construtora?.id === 5 && (
+              {user.role.now && (
                 <Box>
                   <Alert
                     justifyContent="space-between"
@@ -206,10 +199,6 @@ export function CardUpdateSolicitacao({ setDadosCard, user }: Props) {
                     Apenas para clientes presentes no Plantão de Venda.
                     <BtnAlertNow
                       id={setDadosCard.id}
-                      andamento={setDadosCard.andamento}
-                      ativo={setDadosCard.ativo}
-                      distrato={setDadosCard.distrato ?? false}
-                      construtora={setDadosCard.construtora}
                       alertanow={setDadosCard.alertanow}
                     />
                   </Alert>


### PR DESCRIPTION
- Exibe o componente de alerta now apenas para usuários que possuem a role now.
- Remove a verificação da construtora para exibir o alerta, agora depende apenas da role do usuário.