### PR TITLE
🔨 chore: Atualiza .gitignore para ignorar logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn.lock
 
 certificate
 build-log.txt
+
+logs
+log.txt


### PR DESCRIPTION
- Adiciona arquivos de log para serem ignorados.