### PR TITLE
✨ feat: adiciona suporte ao status de represamento na listagem de dados

### DIFF
--- a/src/components/home/lista/index.tsx
+++ b/src/components/home/lista/index.tsx
@@ -528,6 +528,7 @@ export const DadoCompomentList = ({
                 <option value="APROVADO">APROVADO</option>
                 <option value="EMITIDO">EMITIDO</option>
                 <option value="REVOGADO">REVOGADO</option>
+                <option value="REPRESAMENTO">REPRESAMENTO</option>
               </Select>
             </Box>
 

--- a/src/components/home/lista/table.tsx
+++ b/src/components/home/lista/table.tsx
@@ -30,6 +30,8 @@ export const TableComponent = memo(
           ? "red.300"
           : dados.pause
           ? "yellow.200"
+          : dados.andamento === "REPRESAMENTO"
+          ? "orange.200"
           : dados.andamento === "APROVADO"
           ? "green.200"
           : dados.andamento === "EMITIDO"
@@ -41,8 +43,15 @@ export const TableComponent = memo(
     );
 
     const Textcolor = useMemo(
-      () => (dados.distrato ? "white" : !dados.ativo ? "white" : "black"),
-      [dados.distrato, dados.ativo]
+      () =>
+        dados.distrato
+          ? "white"
+          : !dados.ativo
+          ? "white"
+          : dados.andamento === "REPRESAMENTO"
+          ? "black"
+          : "black",
+      [dados.distrato, dados.ativo, dados.andamento]
     );
 
     const formatarDataAgendamento = useCallback(


### PR DESCRIPTION
- Adiciona a opção REPRESAMENTO ao componente de seleção de filtros em DadoCompomentList
- Implementa estilização condicional no TableComponent para aplicar a cor orange.200 ao fundo da linha quando o status for REPRESAMENTO
- Atualiza a lógica de cor de texto e as dependências do useMemo para suportar o novo status de andamento na tabela