### PR TITLE
♻️ refactor: ajusta verificações de permissão nas rotas de alertas

### DIFF
--- a/src/app/api/alerts/geral/cont/route.ts
+++ b/src/app/api/alerts/geral/cont/route.ts
@@ -9,9 +9,7 @@ export async function GET() {
     if (!session) {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
-    if (!session.user?.role?.alert) {
-      return NextResponse.json([], { status: 200 });
-    }
+
     const url = `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/alert/cont`;
     const get = await fetch(url, {
       method: "GET",

--- a/src/app/api/alerts/geral/findAll/route.ts
+++ b/src/app/api/alerts/geral/findAll/route.ts
@@ -9,9 +9,7 @@ export async function GET(request: Request) {
     if (!session) {
       return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
-    if (!session.user?.role?.alert) {
-      return NextResponse.json([], { status: 200 });
-    }
+
     const url = `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/alert`;
     const get = await fetch(url, {
       method: "GET",

--- a/src/app/api/alerts/geral/route.ts
+++ b/src/app/api/alerts/geral/route.ts
@@ -5,40 +5,40 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request) {
-    try {
-        const session = await GetSessionServer();
-        if (!session) {
-            return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-        }
-        if (!session.user?.role?.alert) {
-            return NextResponse.json(
-                { message: "Você não tem permissão para adicionar um alerta" },
-                { status: 401 }
-            );
-        }
-        const body = await request.json();
-        const response = await fetch(
-            `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/alert`,
-            {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${session?.token}`,
-                },
-                body: JSON.stringify(body),
-            }
-        );
-        const retorno = await response.json();
-        if (!response.ok) {
-            throw new Error(retorno.message || "Erro ao adicionar alerta");
-        }
-        revalidateTag("alert-geral-all");
-        return NextResponse.json(retorno, { status: 200 });
-    } catch (error: any) {
-        console.log("🚀 ~ error:", error)
-        return NextResponse.json(
-            { message: error.message || error.message.join("\n") },
-            { status: 500 }
-        );
+  try {
+    const session = await GetSessionServer();
+    if (!session) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
+    if (!session.user?.role?.alert) {
+      return NextResponse.json(
+        { message: "Você não tem permissão para adicionar um alerta" },
+        { status: 401 }
+      );
+    }
+    const body = await request.json();
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/alert`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.token}`,
+        },
+        body: JSON.stringify(body),
+      }
+    );
+    const retorno = await response.json();
+    if (!response.ok) {
+      throw new Error(retorno.message || "Erro ao adicionar alerta");
+    }
+    revalidateTag("alert-geral-all");
+    return NextResponse.json(retorno, { status: 200 });
+  } catch (error: any) {
+    console.log("🚀 ~ error:", error);
+    return NextResponse.json(
+      { message: error.message || error.message.join("\n") },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
- Remove a restrição da permissão role.alert nos endpoints GET de contagem e listagem geral.
- Mantém a obrigatoriedade de sessão autenticada para acesso aos dados da API de alertas.
- Padroniza a indentação e formatação do código no endpoint principal de criação de alertas.